### PR TITLE
Added agenda items for Aug 23rd meeting

### DIFF
--- a/agendas/2023/2023-08-23.md
+++ b/agendas/2023/2023-08-23.md
@@ -109,3 +109,5 @@ This is an open meeting in which anyone in the GraphQL community may attend.
 3. Determine volunteers for note taking (1m, Organizer)
 4. Review agenda (2m, Organizer)
 5. Review previous meeting's action items (5m, Organizer)
+6. Agreement to remove error handling and null propagation from the proposal
+7. Decision on whether a "stripped back" CCN is just the ! modifier or both ! and ? as nullability modifiers


### PR DESCRIPTION
Adds agenda items that need discussion as a result of the WG meeting on Aug 3rd.

_I have added these but I will not be attending that meeting. They will need an owner or organizer to keep the discussions on track._